### PR TITLE
Fix #2

### DIFF
--- a/castep_elnes_parser.py
+++ b/castep_elnes_parser.py
@@ -491,7 +491,7 @@ def get_smeared_spectrum(energies, sigma=0.3, calc_dir=".", seed_name="case_elne
         e_origin_value = np.min(
             [
                 [
-                    ev[int((ne * spectrum["num_spins"] - 1) // 2)]
+                    ev[int(ne // (2 / spectrum["num_spins"]))]
                     for ev, ne in zip(ev_k, spectrum["num_electrons"])
                 ]
                 for ev_k in spectrum["eigenvalues"]

--- a/castep_elnes_parser.py
+++ b/castep_elnes_parser.py
@@ -503,12 +503,13 @@ def get_smeared_spectrum(energies, sigma=0.3, calc_dir=".", seed_name="case_elne
         [
             [
                 [
-                    kw * np.array(
+                    kw * np.sum(
                         [
-                            gaussian(energies, e, w, sigma)
-                            for e, w in zip(spectrum["eigenvalues"][i_kp, i_spin] - e_origin_value, spectrum["dsf"][i_kp, i_spin, i_proj, :, i_ra])
-                            if e >= 0.
-                        ]
+                            gaussian(energies, en, w, sigma)
+                            for en, w in zip(spectrum["eigenvalues"][i_kp, i_spin] - e_origin_value, spectrum["dsf"][i_kp, i_spin, i_proj, :, i_ra])
+                            if en >= 0.
+                        ],
+                        axis=0
                     )
                     for i_kp, kw in enumerate(spectrum["kpoint_weights"])
                 ]
@@ -518,6 +519,6 @@ def get_smeared_spectrum(energies, sigma=0.3, calc_dir=".", seed_name="case_elne
         ]
         for i_proj in range(spectrum["tot_core_projectors"])
     ]
-    sp = np.sum(np.array(sp), axis=(2, 3, 4))
+    sp = np.sum(np.array(sp), axis=(2, 3))
     sp *= 2. / spectrum["num_spins"] # consider spin multiplicity
     return sp


### PR DESCRIPTION
## Summary

- The method of determining the energy eigenvalue of the excitation origin has been modified to be correct for calculations that take into account spin polarization and the case with an even number of electrons per spin.
-  Change to take the sum of Gaussian functions with respect to eigenvalues in list comprehensions because the number of eigenvalues can differ from spin.

## Purpose

- Fix #2
- In general, there is a difference in the number of eigenvalues for each spin, which yields an error when summing up by `np.sum` after making a array by list comprehension.

## Note
Calculation results for systems with odd number of electrons, where spin polarization is not taken into account, have not been a problem in the past, and this change will produce the same results.
