### PR TITLE
Fix setup.cfg and add __version__

### DIFF
--- a/ceparser.py
+++ b/ceparser.py
@@ -25,6 +25,8 @@ import os
 import re
 import struct
 import numpy as np
+import importlib_metadata
+__version__ = importlib_metadata.version('castep_elnes_parser')
 
 def split_castep(filename):
     """

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,5 +15,5 @@ classifiers =
 keywords = tools
 
 [options]
-packages = find:
+py_modules = ceparser
 install_requires = numpy


### PR DESCRIPTION
## Summary
- Fix option section in `setup.cfg` to install the module correctly.
- Add `ceparser.__version__` variable